### PR TITLE
Make Jekyll format tables correctly in GitHub pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+# To format tables correctly, use GitHub-Flavored Markdown (GFM)
+markdown: GFM


### PR DESCRIPTION
Used GitHub-Flavored Markdown (GFM) in Jekyll's `_config.yml` to format markdown tables in the same way as in GitHub repos